### PR TITLE
Adding X-Server-Password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+### Added
+- `X-Server-Password` header with corresponding `serverPassword` field for protected private servers
+
 ## [1.1.2] - 2016-11-18
 ### Added
 - Invalidate token on 401 responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - `X-Server-Password` header with corresponding `serverPassword` field for protected private servers
 
+### Changed
+- Upgraded dependencies
+
 ## [1.1.2] - 2016-11-18
 ### Added
 - Invalidate token on 401 responses

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ const client = new ScreepsModules({
   password: 'PASSWORD',
   token: 'TOKEN'
   serverUrl: 'https://screeps.com',
+  serverPassword: 'SERVER_PASS',
   gzip: false
 }
 ```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = class ScreepsModules {
       password: '',
       token: '',
       serverUrl: 'https://screeps.com',
+      serverPassword: '',
       gzip: false
     }, options)
   }
@@ -139,7 +140,7 @@ module.exports = class ScreepsModules {
       return
     }
 
-    const {email, password, token} = this.options
+    const {email, password, token, serverPassword} = this.options
 
     if (token !== '') {
       options.headers = Object.assign({}, options.headers, {
@@ -151,6 +152,12 @@ module.exports = class ScreepsModules {
         username: email,
         password
       }
+    }
+
+    if (serverPassword) {
+      options.headers = Object.assign({}, options.headers, {
+        'X-Server-Password': serverPassword
+      })
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
     "request": "^2.79.0"
   },
   "devDependencies": {
-    "ava": "^0.17.0",
-    "codecov": "^1.0.1",
+    "ava": "^0.18.2",
+    "codecov": "^2.1.0",
     "commitizen": "^2.8.6",
-    "cz-conventional-changelog": "^1.2.0",
+    "cz-conventional-changelog": "^2.0.0",
     "nock": "https://github.com/node-nock/nock#2e56026",
     "nyc": "^10.0.0",
     "snazzy": "^6.0.0",
-    "standard": "^8.5.0"
+    "standard": "^10.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -136,6 +136,25 @@ test('Test custom server URL', async t => {
   }).commit()
 })
 
+test('Test custom server password', async t => {
+  t.plan(1)
+
+  nock('http://localhost:8888')
+    .matchHeader('X-Server-Password', 'foobar')
+    .post('/api/user/code')
+    .reply(() => {
+      t.pass()
+
+      return ok
+    })
+
+  await new ScreepsModules({
+    serverUrl: 'http://localhost:8888/',
+    serverPassword: 'foobar'
+  }).commit()
+
+})
+
 test('Test commit without branch', async t => {
   t.plan(1)
 

--- a/test.js
+++ b/test.js
@@ -152,7 +152,6 @@ test('Test custom server password', async t => {
     serverUrl: 'http://localhost:8888/',
     serverPassword: 'foobar'
   }).commit()
-
 })
 
 test('Test commit without branch', async t => {


### PR DESCRIPTION
This PR introduces the `X-Server-Password` header for private servers.
When a private server is started with the `--password` option, the screeps-modules package (and therefore the screeps-webpack-plugin) is not able to upload the code anymore. There needs to be a `x-server-password` header with the corresponding password.

This adds the header (and a test of course).